### PR TITLE
Add missing dependencies to nodes

### DIFF
--- a/nodes/adaptors/DataTypeConvertor/package.json
+++ b/nodes/adaptors/DataTypeConvertor/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "undefined",
   "main": "DataTypeConvertor.js",
-  "node-red" : {
+  "node-red": {
     "nodes": {
       "DataTypeConvertor": "DataTypeConvertor.js"
     }
+  },
+  "dependencies": {
+    "request": "^2.88.0"
   }
 }

--- a/nodes/adaptors/Encoder/package.json
+++ b/nodes/adaptors/Encoder/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "undefined",
   "main": "Encoder.js",
-  "node-red" : {
+  "node-red": {
     "nodes": {
       "Encoder": "Encoder.js"
     }
+  },
+  "dependencies": {
+    "request": "^2.88.0"
   }
 }

--- a/nodes/adaptors/TemperatureUnitConvertor/package.json
+++ b/nodes/adaptors/TemperatureUnitConvertor/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "undefined",
   "main": "TemperatureUnitConvertor.js",
-  "node-red" : {
+  "node-red": {
     "nodes": {
       "TemperatureUnitConvertor": "TemperatureUnitConvertor.js"
     }
+  },
+  "dependencies": {
+    "request": "^2.88.0"
   }
 }

--- a/nodes/examples/TemperatureDevice/package.json
+++ b/nodes/examples/TemperatureDevice/package.json
@@ -7,5 +7,8 @@
         "nodes": {
             "ValveStatus": "TemperatureDevice.js"
         }
+    },
+    "dependencies": {
+        "node-red-contrib-coap": "^0.3.0"
     }
 }

--- a/nodes/examples/Thermostat/package.json
+++ b/nodes/examples/Thermostat/package.json
@@ -7,5 +7,8 @@
         "nodes": {
             "Thermostat": "Thermostat.js"
         }
+    },
+    "dependencies": {
+        "node-red-contrib-coap": "^0.3.0"
     }
 }


### PR DESCRIPTION
This PR fixes the following:
- The adaptors were missing the 'request' npm module dependency
- The examples were missing the 'coap' npm module dependency